### PR TITLE
ci: bump setup-node to Node 24

### DIFF
--- a/.github/workflows/build-manifest.yml
+++ b/.github/workflows/build-manifest.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install manifest deps
         working-directory: .github/scripts


### PR DESCRIPTION
Bumps `actions/setup-node` from Node 20 to **Node 24** (active LTS). One-line change, no other workflow edits.

## ⚠️ CI cannot verify this on the PR
`build-manifest.yml` triggers on `push: [main]` **and** has `paths-ignore: '.github/workflows/**'`. It will not run on this PR, and will not run on the merge commit either — only on a later unrelated content push. This change is effectively unverified until then.