### PR TITLE
feat: publish a prebuilt detail file per cabinet

### DIFF
--- a/.github/scripts/build-manifest.mjs
+++ b/.github/scripts/build-manifest.mjs
@@ -17,13 +17,20 @@
  *   - `cover` is the filename of the first cover.{jpg,png,webp} found in
  *     the cabinet root. Clients build a URL via raw.githubusercontent.com.
  */
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
 import yaml from "js-yaml";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..", "..");
+
+// Per-cabinet detail files live here, deliberately outside every cabinet
+// directory: an import copies a cabinet folder verbatim, and a generated
+// file inside one would land in the user's workspace.
+const DETAIL_DIR = "details";
 
 const SLUG_DOMAIN = {
   agency: "Professional Services",
@@ -65,53 +72,123 @@ function readYamlFile(p) {
   }
 }
 
-function readFrontmatter(p) {
-  if (!fs.existsSync(p)) return {};
-  const raw = fs.readFileSync(p, "utf8");
-  const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (!m) return {};
+// gray-matter, not a regex: the app parses these same files with it, and a
+// hand-rolled fence match disagrees with it on an empty `---\n---` block, an
+// unterminated block, a trailing space after the fence, a language tag and a
+// BOM. Returns null when the frontmatter will not parse, which is what the
+// app does with an agent it cannot read.
+function parseFrontmatter(p) {
+  if (!fs.existsSync(p)) return null;
   try {
-    return yaml.load(m[1]) || {};
+    return matter(fs.readFileSync(p, "utf8")).data || {};
   } catch {
-    return {};
+    return null;
   }
 }
 
-function countAgents(cabinetDir) {
+function readFrontmatter(p) {
+  return parseFrontmatter(p) || {};
+}
+
+function readBody(p) {
+  if (!fs.existsSync(p)) return "";
+  try {
+    return matter(fs.readFileSync(p, "utf8")).content.trim();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * The committed files under a cabinet, relative to it. Read from git rather
+ * than the filesystem: .gitignore excludes runtime output (transcripts,
+ * .cabinet-state, dated agent artefacts) that exists in a working copy but
+ * never reaches GitHub, and a path in this list that is not in the repo is a
+ * 404 for the importer downloading it.
+ */
+function listFiles(slug) {
+  const out = execFileSync("git", ["ls-files", "-z", "--", slug], {
+    cwd: ROOT,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const prefix = `${slug}/`;
+  return out
+    .split("\0")
+    .filter((f) => f.startsWith(prefix))
+    .map((f) => f.slice(prefix.length))
+    .sort();
+}
+
+function collectAgents(cabinetDir) {
   const dir = path.join(cabinetDir, ".agents");
-  if (!fs.existsSync(dir)) return 0;
-  let n = 0;
-  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+  if (!fs.existsSync(dir)) return [];
+  const agents = [];
+  const entries = fs
+    .readdirSync(dir, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name));
+  for (const e of entries) {
     if (!e.isDirectory()) continue;
-    if (fs.existsSync(path.join(dir, e.name, "persona.md"))) n += 1;
+    const persona = path.join(dir, e.name, "persona.md");
+    if (!fs.existsSync(persona)) continue;
+    const fm = parseFrontmatter(persona);
+    if (!fm) continue;
+    agents.push({
+      name: fm.name || e.name,
+      slug: fm.slug || e.name,
+      emoji: fm.emoji || "",
+      type: fm.type || "specialist",
+      department: fm.department || "",
+      role: fm.role || "",
+      heartbeat: fm.heartbeat || "",
+    });
   }
-  return n;
+  return agents;
 }
 
-function countJobs(cabinetDir) {
+function collectJobs(cabinetDir) {
   const dir = path.join(cabinetDir, ".jobs");
-  if (!fs.existsSync(dir)) return 0;
-  return fs
-    .readdirSync(dir)
-    .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).length;
+  if (!fs.existsSync(dir)) return [];
+  const jobs = [];
+  for (const f of fs.readdirSync(dir).sort()) {
+    if (!f.endsWith(".yaml") && !f.endsWith(".yml")) continue;
+    const data = readYamlFile(path.join(dir, f));
+    if (!data?.id) continue;
+    jobs.push({
+      id: data.id,
+      name: data.name || "",
+      description: data.description || "",
+      ownerAgent: data.ownerAgent || "",
+      enabled: data.enabled !== false,
+      schedule: data.schedule || "",
+    });
+  }
+  return jobs;
 }
 
-function countChildCabinets(rootDir) {
-  let count = 0;
+function collectChildCabinets(rootDir) {
+  const children = [];
   function scan(dir) {
-    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entries = fs
+      .readdirSync(dir, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const e of entries) {
       if (!e.isDirectory() || e.name.startsWith(".")) continue;
       const full = path.join(dir, e.name);
       if (fs.existsSync(path.join(full, ".cabinet"))) {
-        count += 1;
-        scan(full);
-      } else {
-        scan(full);
+        const meta = readYamlFile(path.join(full, ".cabinet")) || {};
+        children.push({
+          path: path.relative(rootDir, full).split(path.sep).join("/"),
+          name: meta.name || e.name,
+          agents: collectAgents(full),
+          jobs: collectJobs(full),
+        });
       }
+      scan(full);
     }
   }
   scan(rootDir);
-  return count;
+  return children;
 }
 
 function findCover(cabinetDir) {
@@ -123,6 +200,7 @@ function findCover(cabinetDir) {
 
 function build() {
   const cabinets = [];
+  const details = [];
   for (const entry of fs.readdirSync(ROOT, { withFileTypes: true })) {
     if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
     const dir = path.join(ROOT, entry.name);
@@ -132,34 +210,80 @@ function build() {
     const meta = readYamlFile(cabinetFile) || {};
     if (meta.kind && meta.kind !== "root") continue;
 
-    const fm = readFrontmatter(path.join(dir, meta.entry || "index.md"));
+    const entryFile = path.join(dir, meta.entry || "index.md");
+    const fm = readFrontmatter(entryFile);
     const tags = Array.isArray(fm.tags) ? fm.tags : [];
+
+    const agents = collectAgents(dir);
+    const jobs = collectJobs(dir);
+    const children = collectChildCabinets(dir);
+    const name = meta.name || entry.name;
+    const description = meta.description || "";
+    const version = meta.version || "0.1.0";
 
     cabinets.push({
       slug: entry.name,
-      name: meta.name || entry.name,
-      description: meta.description || "",
-      version: meta.version || "0.1.0",
+      name,
+      description,
+      version,
       domain: meta.domain || SLUG_DOMAIN[entry.name] || "Other",
       cover: findCover(dir),
-      agentCount: countAgents(dir),
-      jobCount: countJobs(dir),
-      childCount: countChildCabinets(dir),
+      agentCount: agents.length,
+      jobCount: jobs.length,
+      childCount: children.length,
       tags,
+    });
+
+    // Markdown, not rendered HTML: the app renders it, so the wiki-link
+    // stripping and the remark pipeline stay versioned with the app instead
+    // of freezing into 164 generated files here.
+    details.push({
+      schemaVersion: 1,
+      slug: entry.name,
+      meta: { name, description, version },
+      tags,
+      readme: readBody(entryFile),
+      agents,
+      jobs,
+      children,
+      files: listFiles(entry.name),
     });
   }
   cabinets.sort((a, b) => a.slug.localeCompare(b.slug));
+  details.sort((a, b) => a.slug.localeCompare(b.slug));
   return {
-    schemaVersion: 1,
-    generatedAt: new Date().toISOString(),
-    cabinetCount: cabinets.length,
-    cabinets,
+    manifest: {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      cabinetCount: cabinets.length,
+      cabinets,
+    },
+    details,
   };
 }
 
-const manifest = build();
+const { manifest, details } = build();
+
 const outPath = path.join(ROOT, "manifest.json");
 fs.writeFileSync(outPath, JSON.stringify(manifest, null, 2) + "\n");
+
+// No generatedAt in a detail file, so it only changes when the cabinet does
+// and the commit-back stays empty on a no-op build. Files for cabinets that
+// no longer exist are deleted, otherwise a removed slug keeps answering.
+const detailDir = path.join(ROOT, DETAIL_DIR);
+fs.mkdirSync(detailDir, { recursive: true });
+const wanted = new Set(details.map((d) => `${d.slug}.json`));
+for (const f of fs.readdirSync(detailDir)) {
+  if (f.endsWith(".json") && !wanted.has(f)) fs.rmSync(path.join(detailDir, f));
+}
+for (const detail of details) {
+  fs.writeFileSync(
+    path.join(detailDir, `${detail.slug}.json`),
+    JSON.stringify(detail, null, 2) + "\n"
+  );
+}
+
 console.log(
   `Wrote ${path.relative(ROOT, outPath)} — ${manifest.cabinetCount} cabinets.`
 );
+console.log(`Wrote ${DETAIL_DIR}/ (${details.length} detail files).`);

--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cabinets-manifest-tools",
       "version": "1.0.0",
       "dependencies": {
+        "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0"
       },
       "devDependencies": {
@@ -490,7 +491,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -528,6 +528,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/extract-zip": {
@@ -609,6 +621,43 @@
         "node": ">= 14"
       }
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -671,6 +720,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -706,6 +764,15 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -947,6 +1014,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -1012,6 +1092,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/streamx": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
@@ -1050,6 +1136,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/tar-fs": {

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -8,6 +8,7 @@
     "manifest": "node build-manifest.mjs"
   },
   "dependencies": {
+    "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.0"
   },
   "engines": {

--- a/.github/workflows/build-manifest.yml
+++ b/.github/workflows/build-manifest.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths-ignore:
       - 'manifest.json'
+      - 'details/**'
       - 'README.md'
       - 'CLAUDE.md'
       - 'RELEASE-INDEX.md'
@@ -53,14 +54,16 @@ jobs:
       - name: Build manifest.json
         run: node .github/scripts/build-manifest.mjs
 
-      - name: Commit manifest if changed
+      - name: Commit manifest and details if changed
         run: |
-          if git diff --quiet -- manifest.json; then
-            echo "manifest.json unchanged"
+          # Stage first: the detail files for a brand new cabinet are untracked,
+          # and a plain `git diff` does not see those.
+          git add -A manifest.json details
+          if git diff --cached --quiet; then
+            echo "manifest and details unchanged"
             exit 0
           fi
           git config user.name "cabinet-bot"
           git config user.email "bot@runcabinet.com"
-          git add manifest.json
-          git commit -m "chore: rebuild manifest.json [skip ci]"
+          git commit -m "chore: rebuild manifest.json and details [skip ci]"
           git push


### PR DESCRIPTION
## The problem

Opening a template in the app costs about 14 GitHub Contents API requests, one per directory, because `raw.githubusercontent.com` serves a file but cannot list a folder. The unauthenticated limit is 60 an hour, so roughly four template views exhaust it. After that the app's fetch helpers swallow the 403 and render cabinets with no agents and no jobs.

## The fix

`build-manifest.mjs` already walks every cabinet on the checkout to count its agents and jobs, then throws the parsed data away. It now keeps it and writes `details/<slug>.json` next to `manifest.json`. The app reads one file from the CDN instead of walking, which costs nothing against the API budget.

Each file also carries the cabinet's file list, taken from `git ls-files` rather than the filesystem because `.gitignore` excludes runtime output that exists in a working copy but never reaches GitHub. That list replaces the repo tree call the app made purely to enumerate files for an import.

Frontmatter parsing moves from a hand-rolled regex to `gray-matter`, which is what the app uses. The two disagreed on an empty `---` block, an unterminated block, a trailing space after the fence, a language tag and a BOM. No file in this repo triggers any of those today, but this generator's job is to match the app.

The commit step stages before it diffs, since a new cabinet's detail file is untracked and a plain `git diff` cannot see it.

## Verification

Checked all 163 cabinets: the readme, tags, agents and jobs in every generated file match what the app's own `gray-matter` and `js-yaml` parsing produces, zero mismatches. `manifest.json` regenerates identical apart from `generatedAt`, so the switch from counting to collecting preserved every count.

`details/` is not in this diff on purpose. The action generates and commits it on merge.

## Notes for review

- `details/` sits outside every cabinet directory, so an import never copies it into a user's workspace.
- Nothing existing breaks. `manifest.json` keeps its shape, old app versions only look at slugs from it, and `cabinets-website` skips any top-level directory without a `.cabinet` file.
- No workflow loop. The commit-back keeps `[skip ci]` and `paths-ignore` now lists `details/**`.

The app-side half is cabinetai/cabinet-app. This one merges first; until it does, the app falls back to the old walk.

Model: Claude Opus 5 (1M context). Harness: Claude Code in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
